### PR TITLE
Bugfix: added checking if __cpp_lib_source_location is defined before…

### DIFF
--- a/typo.hpp
+++ b/typo.hpp
@@ -11,7 +11,7 @@
 #endif
 
 #if __has_include(<source_location>) &&\
-        __cplusplus >= __cpp_lib_source_location 
+        defined(__cpp_lib_source_location) && __cplusplus >= __cpp_lib_source_location
 #   include <source_location>
 #endif
 
@@ -128,7 +128,7 @@ constexpr size_t slen(const char (&) [N]) {
 template <typename T>
 inline const char * pretty_name () noexcept {
     #if __has_include(<source_location>) &&\
-        __cplusplus >= __cpp_lib_source_location 
+        defined(__cpp_lib_source_location) && __cplusplus >= __cpp_lib_source_location
     return std::source_location::current().function_name();
     #else
     return PRETTY_FUNC;


### PR DESCRIPTION
Bugfix: added checking if __cpp_lib_source_location is defined before using its value.

It can happen that the __cpp_lib_source_location is not defined and then its value
is considered as 0 and it results in wrong assumptions about existing
source_location header file.
This case is fixed by checking if the __cpp_lib_source_location is defined at all.